### PR TITLE
Fixed misc. source comment typos

### DIFF
--- a/images/credits.txt
+++ b/images/credits.txt
@@ -49,7 +49,7 @@ Cube
 Clipping
 <div>Icons made by <a href="https://www.flaticon.com/authors/smashicons" title="Smashicons">Smashicons</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></div>
 
-View 3d pre-defiened orientation
+View 3d pre-defined orientation
 <div>Icons made by <a href="https://www.flaticon.com/authors/pixel-perfect" title="Pixel perfect">Pixel perfect</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></div>
 
 Stop(dark-theme)

--- a/installer/TEMPLATE_setupvars.iss
+++ b/installer/TEMPLATE_setupvars.iss
@@ -5,7 +5,7 @@
 ; Directory where is located mayo.exe
 #define AppBuildDir "C:\projects\mayo\build-mayo-Qt_5_11_1_MSVC_2017_x64\release"
 
-; Base directory of Qt(same as environement variable QTDIR)
+; Base directory of Qt(same as environment variable QTDIR)
 #define QtDir "C:\libs\Qt-5.11.1_msvc2017_x64\5.11.1\msvc2017_64"
 
 ; Directory for OpenCascade DLLs

--- a/opencascade.pri
+++ b/opencascade.pri
@@ -36,7 +36,7 @@ OCC_VERSION_STR = $$join($$list($$OCC_VERSION_MAJOR, $$OCC_VERSION_MINOR, $$OCC_
 
 message(OpenCascade version $$OCC_VERSION_STR)
 
-# Platform dependant config
+# Platform dependent config
 equals(QT_ARCH, i386) {
   ARCH_BITS_SIZE = 32
 } else:equals(QT_ARCH, x86_64) {

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -790,7 +790,7 @@ Application::IoResult Application::exportStl_gmio(
         for (const DocumentItem* item : docItems) {
             if (progress != nullptr) {
                 progress->setStep(
-                            tr("Writting item %1")
+                            tr("Writing item %1")
                             .arg(item->propertyLabel.value()));
             }
             int error = GMIO_ERROR_OK;

--- a/src/gpx_mesh_item.cpp
+++ b/src/gpx_mesh_item.cpp
@@ -56,7 +56,7 @@ GpxMeshItem::GpxMeshItem(MeshItem *item)
                 MeshVS_DA_InteriorColor,
                 occ::QtUtils::toOccColor(opts->meshDefaultColor()));
     meshVisu->SetDisplayMode(MeshVS_DMF_Shading);
-    // -- Wireframe as default hilight mode
+    // -- Wireframe as default highlight mode
     meshVisu->SetHilightMode(MeshVS_DMF_WireFrame);
     meshVisu->SetMeshSelMethod(MeshVS_MSM_PRECISE);
 


### PR DESCRIPTION
Found via `codespell -q 3  -S ./src/3rdparty -L pres 