### PR TITLE
added settings for MacOS in mayo.pro

### DIFF
--- a/mayo.pro
+++ b/mayo.pro
@@ -39,6 +39,12 @@ release_with_debuginfo:*msvc* {
     QMAKE_CXXFLAGS += -std=c++17
 }
 
+macx {
+    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.14
+    #CASCADE_INC_DIR = /usr/local/occt/include/opencascade  # optional, use with Qt Creator
+    #CASCADE_LIB_DIR = /usr/local/occt/lib                  # optional, use with Qt Creator
+}
+
 INCLUDEPATH += \
     src/app \
     src/3rdparty
@@ -118,6 +124,7 @@ LIBS += \
     -lTKService \
     -lTKShHealing \
     -lTKTopAlgo  \
+    -lTKXSDRAW \
     -lTKV3d  \
     -lTKVCAF \
     -lTKXCAF \


### PR DESCRIPTION
I had to re-add `-lTKXSDRAW`. Also needed to set the MacOS deployment target to 10.14 (or greater) as described in issue #41 .