### PR TITLE
Add a missing #include to fix build

### DIFF
--- a/src/base/cpp_utils.h
+++ b/src/base/cpp_utils.h
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <utility>
 #ifndef __cpp_lib_integer_comparison_functions
+#  include <limits>
 #  include <type_traits>
 #endif
 


### PR DESCRIPTION
In src/base/cpp_utils.h, if __cpp_lib_integer_comparison_functions is not defined, std::numeric_limits is used without #including \<limits\>. This causes the following build error on my computer:

```
g++ -c -pipe -std=c++17 -O2 -g -std=gnu++1z -flto -fno-fat-lto-objects -Wall -Wextra -D_REENTRANT -fPIC -DQT_DISABLE_DEPRECATED_BEFORE=0x050F00 -DHAVE_CONFIG_H -DHAVE_FSTREAM -DHAVE_IOSTREAM -DHAVE_IOMANIP -DHAVE_LIMITS_H -DOCCT_HANDLE_NOCAST -DLIN -DLININTEL -DOCC_CONVERT_SIGNALS -D_OCC64 -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I../../mayo -I. -Isrc/app -I../src/app -I../src/3rdparty -I/usr/include/opencascade -I/usr/include/qt -I/usr/include/qt/QtWidgets -I/usr/include/qt/QtGui -I/usr/include/qt/QtCore -I. -I. -I/usr/lib/qt/mkspecs/linux-g++ -o enumeration.o ../src/base/enumeration.cpp
In file included from ../src/base/enumeration.cpp:9:
../src/base/cpp_utils.h: In function ‘constexpr bool Mayo::CppUtils::inRange(T)’:
../src/base/cpp_utils.h:119:36: error: ‘numeric_limits’ is not a member of ‘std’
  119 |     return cmpGreaterEqual(t, std::numeric_limits<R>::lowest())
      |                                    ^~~~~~~~~~~~~~
../src/base/cpp_utils.h:119:52: error: expected primary-expression before ‘>’ token
  119 |     return cmpGreaterEqual(t, std::numeric_limits<R>::lowest())
      |                                                    ^
../src/base/cpp_utils.h:119:55: error: ‘::lowest’ has not been declared
  119 |     return cmpGreaterEqual(t, std::numeric_limits<R>::lowest())
      |                                                       ^~~~~~
../src/base/cpp_utils.h:120:37: error: ‘numeric_limits’ is not a member of ‘std’
  120 |             && cmpLessEqual(t, std::numeric_limits<R>::max());
      |                                     ^~~~~~~~~~~~~~
../src/base/cpp_utils.h:120:53: error: expected primary-expression before ‘>’ token
  120 |             && cmpLessEqual(t, std::numeric_limits<R>::max());
      |                                                     ^
../src/base/cpp_utils.h:120:56: error: ‘::max’ has not been declared; did you mean ‘std::max’?
  120 |             && cmpLessEqual(t, std::numeric_limits<R>::max());
      |                                                        ^~~
      |                                                        std::max
In file included from /usr/include/c++/11.2.0/array:40,
                 from ../src/3rdparty/gsl/util:22,
                 from ../src/3rdparty/gsl/span:22,
                 from ../src/base/span.h:9,
                 from ../src/base/enumeration.h:9,
                 from ../src/base/enumeration.cpp:7:
/usr/include/c++/11.2.0/bits/stl_algobase.h:300:5: note: ‘std::max’ declared here
  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
```