### PR TITLE
Base: fix crash when no enumeration item

### DIFF
--- a/src/base/property_enumeration.cpp
+++ b/src/base/property_enumeration.cpp
@@ -16,7 +16,7 @@ PropertyEnumeration::PropertyEnumeration(
     )
     : Property(grp, name),
       m_enumeration(enumeration),
-      m_value(enumeration && enumeration->empty() ? enumeration->itemAt(0).value : -1)
+      m_value(enumeration && !enumeration->empty() ? enumeration->itemAt(0).value : -1)
 {
 }
 


### PR DESCRIPTION
```
terminate called after throwing an instance of 'std::out_of_range'
  what():  vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)
Aborted (core dumped)
```

After this commit, it is shown that I have no DXF fonts:

```
PropertyValueConversion::fromVariant() Found no enumeration item for '' [ propertyName=fontNameForTextObjects, propertyType=Mayo::PropertyEnumeration ]
Failed to load setting [path=import/DXF/fontNameForTextObjects]
```
