### PR TITLE
Add LoongArch 64-bit support

### DIFF
--- a/src/3rdparty/fast_float/float_common.h
+++ b/src/3rdparty/fast_float/float_common.h
@@ -10,7 +10,8 @@
        || defined(__MINGW64__)                                          \
        || defined(__s390x__)                                            \
        || (defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) || defined(__PPC64LE__)) \
-       || defined(__EMSCRIPTEN__))
+       || defined(__EMSCRIPTEN__) \
+       || defined(__loongarch_lp64))
 #define FASTFLOAT_64BIT
 #elif (defined(__i386) || defined(__i386__) || defined(_M_IX86)   \
      || defined(__arm__)                                        \


### PR DESCRIPTION
Hi maintainers,
Compiling the mayo failed for loong64 in the Debian Package Auto-Building environment.
The build error log is as follows,
```
[ 27%] Building CXX object CMakeFiles/MayoCore.dir/src/graphics/ais_text.cpp.o
/usr/bin/c++ -DOCCT_HANDLE_NOCAST -DOCC_CONVERT_SIGNALS -DQT_DISABLE_DEPRECATED_BEFORE=0x050F00 -DQT_IMPLICIT_QFILEINFO_CONSTRUCTION -I/<<PKGBUILDDIR>>/obj-loongarch64-linux-gnu/MayoCore_autogen/include -I/<<PKGBUILDDIR>>/src/3rdparty -I/<<PKGBUILDDIR>>/obj-loongarch64-linux-gnu -isystem /usr/include/opencascade -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -std=gnu++17 -MD -MT CMakeFiles/MayoCore.dir/src/graphics/ais_text.cpp.o -MF CMakeFiles/MayoCore.dir/src/graphics/ais_text.cpp.o.d -o CMakeFiles/MayoCore.dir/src/graphics/ais_text.cpp.o -c /<<PKGBUILDDIR>>/src/graphics/ais_text.cpp
In file included from /<<PKGBUILDDIR>>/src/3rdparty/fast_float/ascii_number.h:9,
                 from /<<PKGBUILDDIR>>/src/3rdparty/fast_float/parse_number.h:3,
                 from /<<PKGBUILDDIR>>/src/3rdparty/fast_float/fast_float.h:44,
                 from /<<PKGBUILDDIR>>/src/base/unit_system.cpp:9:
/<<PKGBUILDDIR>>/src/3rdparty/fast_float/float_common.h:20:2: error: #error Unknown platform (not 32-bit, not 64-bit?)
   20 | #error Unknown platform (not 32-bit, not 64-bit?)
      |  ^~~~~
/<<PKGBUILDDIR>>/src/3rdparty/fast_float/float_common.h:161:4: error: #error Not implemented
  161 |   #error Not implemented
      |    ^~~~~
```
The full log can be found at https://buildd.debian.org/status/fetch.php?pkg=mayo&arch=loong64&ver=0.9.0%2Bds-1&stamp=1744735590&raw=0.

Please review this patch.
I have built mayo successfully on my locally.
```
......
   dh_builddeb
dpkg-deb: building package 'mayo' in '../mayo_0.9.0+ds-1+loong64_loong64.deb'.
dpkg-deb: building package 'mayo-dbgsym' in '../mayo-dbgsym_0.9.0+ds-1+loong64_loong64.deb'.
 dpkg-genbuildinfo -O../mayo_0.9.0+ds-1+loong64_loong64.buildinfo
 dpkg-genchanges -O../mayo_0.9.0+ds-1+loong64_loong64.changes
```
Best regards,
Dandan Zhang