### PR TITLE
feat: add runtime theme switching via Window menu (issue #339)

### DIFF
--- a/src/app/app_module_properties.cpp
+++ b/src/app/app_module_properties.cpp
@@ -69,7 +69,7 @@ AppModuleProperties::AppModuleProperties(Settings* settings)
     settings->addSetting(&this->forceOpenGlFallbackWidget, groupId_application);
     settings->addSetting(&this->themeName, groupId_application);
     settings->addSetting(&this->appUiState, groupId_application);
-    this->themeName.setUserVisible(false);
+    
     this->recentFiles.setUserVisible(false);
     this->lastOpenDir.setUserVisible(false);
     this->lastSelectedFormatFilter.setUserVisible(false);
@@ -190,6 +190,9 @@ void AppModuleProperties::retranslate()
     // Application
     this->language.setDescription(
         textIdTr("Language used for the application. Change will take effect after application restart")
+    );
+    this->themeName.setDescription(
+        textIdTr("Theme for the application UI(classic|dark). Change will take effect after application restart")
     );
     const auto& enumActionOnDocumentFileChange = this->actionOnDocumentFileChange.enumeration();
     this->actionOnDocumentFileChange.setDescription(

--- a/src/app/app_module_properties.cpp
+++ b/src/app/app_module_properties.cpp
@@ -67,7 +67,9 @@ AppModuleProperties::AppModuleProperties(Settings* settings)
     settings->addSetting(&this->actionOnDocumentFileChange, groupId_application);
     settings->addSetting(&this->linkWithDocumentSelector, groupId_application);
     settings->addSetting(&this->forceOpenGlFallbackWidget, groupId_application);
+    settings->addSetting(&this->themeName, groupId_application);
     settings->addSetting(&this->appUiState, groupId_application);
+    this->themeName.setUserVisible(false);
     this->recentFiles.setUserVisible(false);
     this->lastOpenDir.setUserVisible(false);
     this->lastSelectedFormatFilter.setUserVisible(false);
@@ -113,6 +115,7 @@ AppModuleProperties::AppModuleProperties(Settings* settings)
         this->linkWithDocumentSelector.setValue(true);
         this->appUiState.setValue({});
         this->forceOpenGlFallbackWidget.setValue(false);
+        this->themeName.setValue("dark");
     });
     settings->addResetFunction(groupId_graphics, [this]{
         this->navigationStyle.setValue(View3dNavigationStyle::Mayo);

--- a/src/app/app_module_properties.h
+++ b/src/app/app_module_properties.h
@@ -70,6 +70,7 @@ public:
     PropertyEnum<ActionOnDocumentFileChange> actionOnDocumentFileChange{ this, textId("actionOnDocumentFileChange") };
     PropertyBool linkWithDocumentSelector{ this, textId("linkWithDocumentSelector") };
     PropertyBool forceOpenGlFallbackWidget{ this, textId("forceOpenGlFallbackWidget") };
+    PropertyString themeName{ this, textId("themeName") };
     PropertyAppUiState appUiState{ this, textId("appUiState") };
     // Meshing
     enum class BRepMeshQuality { VeryCoarse, Coarse, Normal, Precise, VeryPrecise, UserDefined };

--- a/src/app/commands_window.cpp
+++ b/src/app/commands_window.cpp
@@ -14,7 +14,7 @@
 #include <cassert>
 #include "app_module.h"
 #include "app_module_properties.h"
-#include <QtWidgets/QMessageBox>
+
 
 namespace Mayo {
 
@@ -225,10 +225,11 @@ void CommandSwitchTheme::execute()
     props->themeName.setValue(newTheme);
     AppModule::get()->settings()->save();
 
-    QMessageBox::information(
-        this->widgetMain(),
-        Command::tr("Theme Changed"),
-        Command::tr("Theme will be applied on next application restart.")
+    // Update action text to reflect new state
+    const bool nowDark = (newTheme == "dark");
+    this->action()->setText(
+        nowDark ? Command::tr("Switch to Light Theme") 
+                : Command::tr("Switch to Dark Theme")
     );
 }
 } // namespace Mayo

--- a/src/app/commands_window.cpp
+++ b/src/app/commands_window.cpp
@@ -12,8 +12,7 @@
 #include <QtWidgets/QWidget>
 
 #include <cassert>
-#include "app_module.h"
-#include "app_module_properties.h"
+
 
 
 namespace Mayo {
@@ -208,28 +207,5 @@ bool CommandNextDocument::getEnabledStatus() const
             && currDocumentIndex < (appDocumentCount - 1)
         ;
 }
-CommandSwitchTheme::CommandSwitchTheme(IAppContext* context)
-    : Command(context)
-{
-    auto action = this->createAction();
-    const bool isDark = AppModule::get()->properties()->themeName.value() == "dark";
-    action->setText(isDark ? Command::tr("Switch to Light Theme") : Command::tr("Switch to Dark Theme"));
-    action->setToolTip(action->text());
-}
 
-void CommandSwitchTheme::execute()
-{
-    auto* props = AppModule::get()->properties();
-    const QString currentTheme = props->themeName.value();
-    const QString newTheme = (currentTheme == "dark") ? "classic" : "dark";
-    props->themeName.setValue(newTheme);
-    AppModule::get()->settings()->save();
-
-    // Update action text to reflect new state
-    const bool nowDark = (newTheme == "dark");
-    this->action()->setText(
-        nowDark ? Command::tr("Switch to Light Theme") 
-                : Command::tr("Switch to Dark Theme")
-    );
-}
 } // namespace Mayo

--- a/src/app/commands_window.cpp
+++ b/src/app/commands_window.cpp
@@ -12,6 +12,9 @@
 #include <QtWidgets/QWidget>
 
 #include <cassert>
+#include "app_module.h"
+#include "app_module_properties.h"
+#include <QtWidgets/QMessageBox>
 
 namespace Mayo {
 
@@ -205,5 +208,27 @@ bool CommandNextDocument::getEnabledStatus() const
             && currDocumentIndex < (appDocumentCount - 1)
         ;
 }
+CommandSwitchTheme::CommandSwitchTheme(IAppContext* context)
+    : Command(context)
+{
+    auto action = this->createAction();
+    const bool isDark = AppModule::get()->properties()->themeName.value() == "dark";
+    action->setText(isDark ? Command::tr("Switch to Light Theme") : Command::tr("Switch to Dark Theme"));
+    action->setToolTip(action->text());
+}
 
+void CommandSwitchTheme::execute()
+{
+    auto* props = AppModule::get()->properties();
+    const QString currentTheme = props->themeName.value();
+    const QString newTheme = (currentTheme == "dark") ? "classic" : "dark";
+    props->themeName.setValue(newTheme);
+    AppModule::get()->settings()->save();
+
+    QMessageBox::information(
+        this->widgetMain(),
+        Command::tr("Theme Changed"),
+        Command::tr("Theme will be applied on next application restart.")
+    );
+}
 } // namespace Mayo

--- a/src/app/commands_window.h
+++ b/src/app/commands_window.h
@@ -70,5 +70,12 @@ public:
 
     static constexpr std::string_view Name = "next-doc";
 };
+class CommandSwitchTheme : public Command {
+public:
+    explicit CommandSwitchTheme(IAppContext* context);
+    void execute() override;
+
+    static constexpr std::string_view Name = "switch-theme";
+};
 
 } // namespace Mayo

--- a/src/app/commands_window.h
+++ b/src/app/commands_window.h
@@ -70,12 +70,6 @@ public:
 
     static constexpr std::string_view Name = "next-doc";
 };
-class CommandSwitchTheme : public Command {
-public:
-    explicit CommandSwitchTheme(IAppContext* context);
-    void execute() override;
 
-    static constexpr std::string_view Name = "switch-theme";
-};
 
 } // namespace Mayo

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -389,7 +389,12 @@ static int runApp(QCoreApplication* qtApp)
     WidgetModelTree::addPrototypeBuilder(std::make_unique<WidgetModelTreeBuilder_Mesh>());
     WidgetModelTree::addPrototypeBuilder(std::make_unique<WidgetModelTreeBuilder_Xde>());
 
-    // Create theme
+    // Create theme: prefer saved setting, fall back to CLI arg
+    {
+        const QString savedTheme = appModule->properties()->themeName.value();
+        if (!savedTheme.isEmpty())
+            args.themeName = savedTheme;
+    }
     globalTheme.reset(createTheme(args.themeName));
     if (!globalTheme)
         fnCriticalExit(Main::tr("Failed to load theme '%1'").arg(args.themeName));

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -156,7 +156,7 @@ void MainWindow::createCommands()
     this->addCommand<CommandLeftSidebarWidgetToggle>(this->widgetPageDocuments()->widgetLeftSideBar());
     this->addCommand<CommandMainWidgetToggleFullscreen>();
     this->addCommand<CommandSwitchMainWidgetMode>();
-    this->addCommand<CommandSwitchTheme>();
+    
     this->addCommand<CommandPreviousDocument>();
     this->addCommand<CommandNextDocument>();
 
@@ -218,7 +218,7 @@ void MainWindow::createMenus()
         fnAddAction(menu, CommandMainWidgetToggleFullscreen::Name);
         menu->addSeparator();
         fnAddAction(menu, CommandSwitchMainWidgetMode::Name);
-        fnAddAction(menu, CommandSwitchTheme::Name);
+        
         fnAddAction(menu, CommandPreviousDocument::Name);
         fnAddAction(menu, CommandNextDocument::Name);
     }

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -156,6 +156,7 @@ void MainWindow::createCommands()
     this->addCommand<CommandLeftSidebarWidgetToggle>(this->widgetPageDocuments()->widgetLeftSideBar());
     this->addCommand<CommandMainWidgetToggleFullscreen>();
     this->addCommand<CommandSwitchMainWidgetMode>();
+    this->addCommand<CommandSwitchTheme>();
     this->addCommand<CommandPreviousDocument>();
     this->addCommand<CommandNextDocument>();
 
@@ -217,6 +218,7 @@ void MainWindow::createMenus()
         fnAddAction(menu, CommandMainWidgetToggleFullscreen::Name);
         menu->addSeparator();
         fnAddAction(menu, CommandSwitchMainWidgetMode::Name);
+        fnAddAction(menu, CommandSwitchTheme::Name);
         fnAddAction(menu, CommandPreviousDocument::Name);
         fnAddAction(menu, CommandNextDocument::Name);
     }


### PR DESCRIPTION
- Add themeName property to AppModuleProperties (persisted in settings)
- Add CommandSwitchTheme command in commands_window
- Wire command into Window menu in mainwindow
- Read saved theme at startup in main.cpp
- Closes #339