### PR TITLE
App: fix conversion of Quantity_Color into QColor (#373)

### DIFF
--- a/src/app/qstring_utils.cpp
+++ b/src/app/qstring_utils.cpp
@@ -4,6 +4,7 @@
 ****************************************************************************/
 
 #include "qstring_utils.h"
+#include "../base/tkernel_utils.h"
 
 #include <gp_Trsf.hxx>
 #include <Precision.hxx>
@@ -86,10 +87,12 @@ QString QStringUtils::text(const gp_Trsf& trsf, const TextOptions& opt)
 
 QString QStringUtils::text(const Quantity_Color& color, const QString& format)
 {
-    const int red = color.Red() * 255;
-    const int green = color.Green() * 255;
-    const int blue = color.Blue() * 255;
-    return format.arg(red).arg(green).arg(blue);
+    NCollection_Vec3<double> rgb;
+    color.Values(rgb.r(), rgb.g(), rgb.b(), TKernelUtils::preferredRgbColorType());
+    rgb.r() = Round(rgb.r() * 255.);
+    rgb.g() = Round(rgb.g() * 255.);
+    rgb.b() = Round(rgb.b() * 255.);
+    return format.arg(int(rgb.r())).arg(int(rgb.g())).arg(int(rgb.b()));
 }
 
 QString QStringUtils::bytesText(uint64_t sizeBytes, const QLocale& locale)

--- a/src/app/qtgui_utils.cpp
+++ b/src/app/qtgui_utils.cpp
@@ -5,6 +5,7 @@
 
 #include "qtgui_utils.h"
 #include "../base/math_utils.h"
+#include "../base/tkernel_utils.h"
 
 #include <Standard_Version.hxx>
 
@@ -37,7 +38,12 @@ constexpr bool isInRange(double v, double start, double end)
 
 QColor toQColor(const Quantity_Color& c)
 {
-    return QColor(c.Red() * 255., c.Green() * 255., c.Blue() * 255.);
+    NCollection_Vec3<double> rgb;
+    c.Values(rgb.r(), rgb.g(), rgb.b(), TKernelUtils::preferredRgbColorType());
+    rgb.r() = Round(rgb.r() * 255.);
+    rgb.g() = Round(rgb.g() * 255.);
+    rgb.b() = Round(rgb.b() * 255.);
+    return QColor(int(rgb.r()), int(rgb.g()), int(rgb.b()));
 }
 
 QColor toQColor(const Quantity_ColorRGBA& c)


### PR DESCRIPTION
Quantity_TOC_sRGB is now used for getting RGB components within QtGuiUtils::toQColor() and QStringUtils::text()
(colors in 0..255 range are always expected to be in gamma-shifted sRGB colorspace).

<img width="1920" height="1056" alt="image" src="https://github.com/user-attachments/assets/7c0b0acf-142e-4040-9127-a290e59ad28a" />
