### PR TITLE
IO_BREP: add reader of BinXCAF (.xbf) and XmlXCAF (.xml) files

### DIFF
--- a/src/base/io_format.cpp
+++ b/src/base/io_format.cpp
@@ -18,6 +18,8 @@ std::string_view formatIdentifier(Format format)
     case Format_IGES:  return "IGES";
     case Format_OCCBREP: return "OCCBREP";
     case Format_OCCBINBREP: return "OCCBINBREP";
+    case Format_OCCBinXCAF: return "OCCBinXCAF";
+    case Format_OCCXmlXCAF: return "OCCXmlXCAF";
     case Format_STL:   return "STL";
     case Format_OBJ:   return "OBJ";
     case Format_GLTF:  return "GLTF";
@@ -47,6 +49,8 @@ std::string_view formatName(Format format)
     case Format_IGES:  return "IGES(ASME Y14.26M)";
     case Format_OCCBREP: return "OpenCascade BREP";
     case Format_OCCBINBREP: return "OpenCascade Binary BREP";
+    case Format_OCCBinXCAF: return "OpenCascade BinXCAF";
+    case Format_OCCXmlXCAF: return "OpenCascade XmlXCAF";
     case Format_STL:   return "STL(STereo-Lithography)";
     case Format_OBJ:   return "Wavefront OBJ";
     case Format_GLTF:  return "glTF(GL Transmission Format)";
@@ -81,6 +85,8 @@ gsl::span<std::string_view> formatFileSuffixes(Format format)
     static std::string_view suffix_obj[]  = { "obj" };
     static std::string_view suffix_occ[]  = { "brep", "rle", "occ" };
     static std::string_view suffix_occbin[]  = { "binbrep", "bbrep" };
+    static std::string_view suffix_occxbf[]  = { "xbf" };
+    static std::string_view suffix_occxml[]  = { "xml" }; // alas, not very useful for identification...
     static std::string_view suffix_off[]  = { "off" };
     static std::string_view suffix_ply[]  = { "ply" };
     static std::string_view suffix_step[] = { "step", "stp" };
@@ -104,6 +110,8 @@ gsl::span<std::string_view> formatFileSuffixes(Format format)
     case Format_OBJ:   return suffix_obj;
     case Format_OCCBREP: return suffix_occ;
     case Format_OCCBINBREP: return suffix_occbin;
+    case Format_OCCBinXCAF: return suffix_occxbf;
+    case Format_OCCXmlXCAF: return suffix_occxml;
     case Format_OFF:   return suffix_off;
     case Format_PLY:   return suffix_ply;
     case Format_STEP:  return suffix_step;
@@ -119,7 +127,7 @@ gsl::span<std::string_view> formatFileSuffixes(Format format)
 
 bool formatProvidesBRep(Format format)
 {
-    static const Format brepFormats[] = { Format_STEP, Format_IGES, Format_OCCBREP, Format_OCCBINBREP, Format_DXF };
+    static const Format brepFormats[] = { Format_STEP, Format_IGES, Format_OCCBREP, Format_OCCBINBREP, Format_OCCBinXCAF, Format_OCCXmlXCAF, Format_DXF };
     return std::any_of(
                 std::cbegin(brepFormats),
                 std::cend(brepFormats),

--- a/src/base/io_format.cpp
+++ b/src/base/io_format.cpp
@@ -17,6 +17,7 @@ std::string_view formatIdentifier(Format format)
     case Format_STEP:  return "STEP";
     case Format_IGES:  return "IGES";
     case Format_OCCBREP: return "OCCBREP";
+    case Format_OCCBINBREP: return "OCCBINBREP";
     case Format_STL:   return "STL";
     case Format_OBJ:   return "OBJ";
     case Format_GLTF:  return "GLTF";
@@ -45,6 +46,7 @@ std::string_view formatName(Format format)
     case Format_STEP:  return "STEP(ISO 10303)";
     case Format_IGES:  return "IGES(ASME Y14.26M)";
     case Format_OCCBREP: return "OpenCascade BREP";
+    case Format_OCCBINBREP: return "OpenCascade Binary BREP";
     case Format_STL:   return "STL(STereo-Lithography)";
     case Format_OBJ:   return "Wavefront OBJ";
     case Format_GLTF:  return "glTF(GL Transmission Format)";
@@ -78,6 +80,7 @@ gsl::span<std::string_view> formatFileSuffixes(Format format)
     static std::string_view suffix_iges[] = { "iges", "igs" };
     static std::string_view suffix_obj[]  = { "obj" };
     static std::string_view suffix_occ[]  = { "brep", "rle", "occ" };
+    static std::string_view suffix_occbin[]  = { "binbrep", "bbrep" };
     static std::string_view suffix_off[]  = { "off" };
     static std::string_view suffix_ply[]  = { "ply" };
     static std::string_view suffix_step[] = { "step", "stp" };
@@ -100,6 +103,7 @@ gsl::span<std::string_view> formatFileSuffixes(Format format)
     case Format_IGES:  return suffix_iges;
     case Format_OBJ:   return suffix_obj;
     case Format_OCCBREP: return suffix_occ;
+    case Format_OCCBINBREP: return suffix_occbin;
     case Format_OFF:   return suffix_off;
     case Format_PLY:   return suffix_ply;
     case Format_STEP:  return suffix_step;
@@ -115,7 +119,7 @@ gsl::span<std::string_view> formatFileSuffixes(Format format)
 
 bool formatProvidesBRep(Format format)
 {
-    static const Format brepFormats[] = { Format_STEP, Format_IGES, Format_OCCBREP, Format_DXF };
+    static const Format brepFormats[] = { Format_STEP, Format_IGES, Format_OCCBREP, Format_OCCBINBREP, Format_DXF };
     return std::any_of(
                 std::cbegin(brepFormats),
                 std::cend(brepFormats),

--- a/src/base/io_format.h
+++ b/src/base/io_format.h
@@ -24,6 +24,7 @@ enum Format {
     Format_IGES,
     Format_OBJ,
     Format_OCCBREP,
+    Format_OCCBINBREP,
     Format_OFF,
     Format_PLY,
     Format_STEP,

--- a/src/base/io_format.h
+++ b/src/base/io_format.h
@@ -25,6 +25,8 @@ enum Format {
     Format_OBJ,
     Format_OCCBREP,
     Format_OCCBINBREP,
+    Format_OCCBinXCAF,
+    Format_OCCXmlXCAF,
     Format_OFF,
     Format_PLY,
     Format_STEP,

--- a/src/base/io_system.cpp
+++ b/src/base/io_system.cpp
@@ -610,8 +610,13 @@ Format probeFormat_IGES(const System::FormatProbeInput& input)
 
 Format probeFormat_OCCBREP(const System::FormatProbeInput& input)
 {
-    const std::regex rx{ R"(^\s*DBRep_DrawableShape)" };
-    return matchRegExp_atStart(input.contentsBegin, rx) ? Format_OCCBREP : Format_Unknown;
+    const std::regex rxAscii{ R"(^\s*DBRep_DrawableShape)" };
+    if (matchRegExp_atStart(input.contentsBegin, rxAscii)) {
+        return Format_OCCBREP;
+    }
+
+    const std::regex rxBin{ R"(^\s*Open CASCADE Topology V)" };
+    return matchRegExp_atStart(input.contentsBegin, rxBin) ? Format_OCCBINBREP : Format_Unknown;
 }
 
 Format probeFormat_STL(const System::FormatProbeInput& input)

--- a/src/base/io_system.cpp
+++ b/src/base/io_system.cpp
@@ -619,6 +619,14 @@ Format probeFormat_OCCBREP(const System::FormatProbeInput& input)
     return matchRegExp_atStart(input.contentsBegin, rxBin) ? Format_OCCBINBREP : Format_Unknown;
 }
 
+Format probeFormat_OCCXCAF(const System::FormatProbeInput& input)
+{
+    // binary XCAF starts with "BINFILE" which is too short for a reliable identification...
+
+    const std::regex rxXml{ R"(^\s*"<document format=\"XmlXCAF\"")" };
+    return matchRegExp_atStart(input.contentsBegin, rxXml) ? Format_OCCXmlXCAF : Format_Unknown;
+}
+
 Format probeFormat_STL(const System::FormatProbeInput& input)
 {
     std::string_view sample = input.contentsBegin;
@@ -676,6 +684,7 @@ void addPredefinedFormatProbes(System* system)
     system->addFormatProbe(probeFormat_STEP);
     system->addFormatProbe(probeFormat_IGES);
     system->addFormatProbe(probeFormat_OCCBREP);
+    system->addFormatProbe(probeFormat_OCCXCAF);
     system->addFormatProbe(probeFormat_STL);
     system->addFormatProbe(probeFormat_OBJ);
     system->addFormatProbe(probeFormat_PLY);

--- a/src/base/io_system.h
+++ b/src/base/io_system.h
@@ -207,6 +207,7 @@ private:
 Format probeFormat_STEP(const System::FormatProbeInput& input);
 Format probeFormat_IGES(const System::FormatProbeInput& input);
 Format probeFormat_OCCBREP(const System::FormatProbeInput& input);
+Format probeFormat_OCCXCAF(const System::FormatProbeInput& input);
 Format probeFormat_STL(const System::FormatProbeInput& input);
 Format probeFormat_OBJ(const System::FormatProbeInput& input);
 Format probeFormat_PLY(const System::FormatProbeInput& input);

--- a/src/io_occ/io_occ.cpp
+++ b/src/io_occ/io_occ.cpp
@@ -12,6 +12,7 @@
 #include "io_occ_step.h"
 #include "io_occ_stl.h"
 #include "io_occ_vrml_writer.h"
+#include "io_occ_xcaf.h"
 
 #if OCC_VERSION_HEX >= OCC_VERSION_CHECK(7, 4, 0)
 #  include "io_occ_gltf_reader.h"
@@ -44,6 +45,10 @@ gsl::span<const Format> OccFactoryReader::formats() const
     #if OCC_VERSION_HEX >= OCC_VERSION_CHECK(7, 7, 0)
         , Format_VRML
     #endif
+    // XCAF persistence exists for a long time in OCCT, but XCAFDoc_Editor::Extract() has been added in OCCT 7.6
+    #if OCC_VERSION_HEX >= OCC_VERSION_CHECK(7, 6, 0)
+        , Format_OCCBinXCAF, Format_OCCXmlXCAF
+    #endif
     };
     return arrayFormat;
 }
@@ -58,6 +63,8 @@ std::unique_ptr<Reader> OccFactoryReader::create(Format format) const
         return std::make_unique<OccBRepReader>(false);
     if (format == Format_OCCBINBREP)
         return std::make_unique<OccBRepReader>(true);
+    if (format == Format_OCCBinXCAF || format == Format_OCCXmlXCAF)
+        return std::make_unique<OccXCafReader>();
     if (format == Format_STL)
         return std::make_unique<OccStlReader>();
 
@@ -101,7 +108,9 @@ PtrPropertyGroup OccFactoryReader::createProperties(Format format, PropertyGroup
 gsl::span<const Format> OccFactoryWriter::formats() const
 {
     static const Format arrayFormat[] = {
-        Format_STEP, Format_IGES, Format_OCCBREP, Format_OCCBINBREP, Format_STL, Format_VRML
+        Format_STEP, Format_IGES,
+        Format_OCCBREP, Format_OCCBINBREP,
+        Format_STL, Format_VRML
     #if OCC_VERSION_HEX >= OCC_VERSION_CHECK(7, 5, 0)
         , Format_GLTF
     #endif

--- a/src/io_occ/io_occ.cpp
+++ b/src/io_occ/io_occ.cpp
@@ -37,7 +37,7 @@ namespace { using PtrPropertyGroup = std::unique_ptr<PropertyGroup>; }
 gsl::span<const Format> OccFactoryReader::formats() const
 {
     static const Format arrayFormat[] = {
-        Format_STEP, Format_IGES, Format_OCCBREP, Format_STL
+        Format_STEP, Format_IGES, Format_OCCBREP, Format_OCCBINBREP, Format_STL
     #if OCC_VERSION_HEX >= OCC_VERSION_CHECK(7, 4, 0)
         , Format_GLTF, Format_OBJ
     #endif
@@ -55,7 +55,9 @@ std::unique_ptr<Reader> OccFactoryReader::create(Format format) const
     if (format == Format_IGES)
         return std::make_unique<OccIgesReader>();
     if (format == Format_OCCBREP)
-        return std::make_unique<OccBRepReader>();
+        return std::make_unique<OccBRepReader>(false);
+    if (format == Format_OCCBINBREP)
+        return std::make_unique<OccBRepReader>(true);
     if (format == Format_STL)
         return std::make_unique<OccStlReader>();
 
@@ -99,7 +101,7 @@ PtrPropertyGroup OccFactoryReader::createProperties(Format format, PropertyGroup
 gsl::span<const Format> OccFactoryWriter::formats() const
 {
     static const Format arrayFormat[] = {
-        Format_STEP, Format_IGES, Format_OCCBREP, Format_STL, Format_VRML
+        Format_STEP, Format_IGES, Format_OCCBREP, Format_OCCBINBREP, Format_STL, Format_VRML
     #if OCC_VERSION_HEX >= OCC_VERSION_CHECK(7, 5, 0)
         , Format_GLTF
     #endif
@@ -117,7 +119,9 @@ std::unique_ptr<Writer> OccFactoryWriter::create(Format format) const
     if (format == Format_IGES)
         return std::make_unique<OccIgesWriter>();
     if (format == Format_OCCBREP)
-        return std::make_unique<OccBRepWriter>();
+        return std::make_unique<OccBRepWriter>(false);
+    if (format == Format_OCCBINBREP)
+        return std::make_unique<OccBRepWriter>(true);
     if (format == Format_STL)
         return std::make_unique<OccStlWriter>();
     if (format == Format_VRML)

--- a/src/io_occ/io_occ_brep.cpp
+++ b/src/io_occ/io_occ_brep.cpp
@@ -15,18 +15,31 @@
 #include "../base/task_progress.h"
 #include "../base/tkernel_utils.h"
 
+#include <BinTools.hxx>
 #include <BRep_Builder.hxx>
 #include <BRepTools.hxx>
 #include <TDataStd_Name.hxx>
 
 namespace Mayo::IO {
 
+OccBRepReader::OccBRepReader(bool binaryMode) : m_isBinary(binaryMode) {
+    //
+}
+
 bool OccBRepReader::readFile(const FilePath& filepath, TaskProgress* progress)
 {
     m_shape.Nullify();
     m_baseFilename = filepath.stem();
-    BRep_Builder brepBuilder;
+
     auto indicator = makeOccHandle<OccProgressIndicator>(progress);
+    if (m_isBinary) {
+        return BinTools::Read(
+            m_shape,
+            filepath.u8string().c_str(),
+            TKernelUtils::start(indicator));
+    }
+
+    BRep_Builder brepBuilder;
     return BRepTools::Read(
         m_shape,
         filepath.u8string().c_str(),
@@ -45,6 +58,10 @@ NCollection_Sequence<TDF_Label> OccBRepReader::transfer(DocumentPtr doc, TaskPro
     shapeTool->SetShape(labelShape, m_shape);
     TDataStd_Name::Set(labelShape, filepathTo<TCollection_ExtendedString>(m_baseFilename));
     return CafUtils::makeLabelSequence({ labelShape });
+}
+
+OccBRepWriter::OccBRepWriter(bool binaryMode) : m_isBinary(binaryMode) {
+    //
 }
 
 bool OccBRepWriter::transfer(gsl::span<const ApplicationItem> appItems, TaskProgress* /*progress*/)
@@ -79,6 +96,10 @@ bool OccBRepWriter::transfer(gsl::span<const ApplicationItem> appItems, TaskProg
 bool OccBRepWriter::writeFile(const FilePath& filepath, TaskProgress* progress)
 {
     auto indicator = makeOccHandle<OccProgressIndicator>(progress);
+    if (m_isBinary) {
+        return BinTools::Write(m_shape, filepath.u8string().c_str(), TKernelUtils::start(indicator));
+    }
+
     return BRepTools::Write(m_shape, filepath.u8string().c_str(), TKernelUtils::start(indicator));
 }
 

--- a/src/io_occ/io_occ_brep.h
+++ b/src/io_occ/io_occ_brep.h
@@ -14,6 +14,7 @@ namespace Mayo::IO {
 // Reader for OpenCascade BRep file format
 class OccBRepReader : public Reader {
 public:
+    OccBRepReader(bool binaryMode = false);
     bool readFile(const FilePath& filepath, TaskProgress* progress) override;
     NCollection_Sequence<TDF_Label> transfer(DocumentPtr doc, TaskProgress* progress) override;
     void applyProperties(const PropertyGroup*) override {}
@@ -21,17 +22,20 @@ public:
 private:
     TopoDS_Shape m_shape;
     FilePath m_baseFilename;
+    bool m_isBinary = false;
 };
 
 // Writer for OpenCascade BRep file format
 class OccBRepWriter : public Writer {
 public:
+    OccBRepWriter(bool binaryMode = false);
     bool transfer(gsl::span<const ApplicationItem> appItems, TaskProgress* progress) override;
     bool writeFile(const FilePath& filepath, TaskProgress* progress) override;
     void applyProperties(const PropertyGroup*) override {}
 
 private:
     TopoDS_Shape m_shape;
+    bool m_isBinary = false;
 };
 
 } // namespace Mayo::IO

--- a/src/io_occ/io_occ_xcaf.cpp
+++ b/src/io_occ/io_occ_xcaf.cpp
@@ -1,0 +1,77 @@
+/****************************************************************************
+** Copyright (c) 2016, Fougue SAS <https://www.fougue.pro>
+** SPDX-License-Identifier: BSD-2-Clause
+****************************************************************************/
+
+#include "io_occ_xcaf.h"
+#include "io_occ_caf.h"
+#include "../base/occ_handle.h"
+#include "../base/string_conv.h"
+#include "../base/task_progress.h"
+#include "../base/tkernel_utils.h"
+#include "../base/occ_progress_indicator.h"
+
+#include <BinXCAFDrivers.hxx>
+#include <TDocStd_Application.hxx>
+#include <XCAFDoc_DocumentTool.hxx>
+#include <XCAFDoc_Editor.hxx>
+#include <XmlXCAFDrivers.hxx>
+
+#include <fmt/format.h>
+#include <stdexcept>
+
+namespace Mayo::IO {
+
+OccXCafReader::OccXCafReader()
+{
+    //
+}
+
+bool OccXCafReader::readFile(const FilePath& filepath, TaskProgress* progress)
+{
+    MayoIO_CafGlobalScopedLock(cafLock);
+
+    try {
+        m_app = makeOccHandle<TDocStd_Application>();
+        XmlXCAFDrivers::DefineFormat(m_app); // to load XML files
+        BinXCAFDrivers::DefineFormat(m_app); // to load XBF files
+    } catch (const Standard_Failure& ) {
+        return false;
+    }
+
+#if OCC_VERSION_HEX >= OCC_VERSION_CHECK(7, 6, 0)
+    auto indicator = makeOccHandle<OccProgressIndicator>(progress);
+    const PCDM_ReaderStatus error = m_app->Open(filepath.u8string().c_str(), m_doc, indicator->Start());
+#else
+    const PCDM_ReaderStatus error = m_app->Open(filepath.u8string().c_str(), m_doc);
+#endif
+    return error == PCDM_RS_OK;
+}
+
+NCollection_Sequence<TDF_Label> OccXCafReader::transfer(DocumentPtr doc, TaskProgress* )
+{
+#if OCC_VERSION_HEX >= OCC_VERSION_CHECK(7, 6, 0)
+    MayoIO_CafGlobalScopedLock(cafLock);
+
+    const NCollection_Sequence<TDF_Label> seqMark = doc->xcaf().topLevelFreeShapes();
+
+    NCollection_Sequence<TDF_Label> newRoots;
+    XCAFDoc_DocumentTool::ShapeTool(m_doc->Main())->GetFreeShapes(newRoots);
+
+    // ideally, it would be better just swapping the documents when target doc is empty,
+    // and therefore avoid copying labels and possible bugs in XCAFDoc_Editor,
+    // but this would require tricky changes in Mayo::IO API
+    XCAFDoc_Editor::Extract(newRoots, doc->Main());
+
+    m_doc->Main().Root().ForgetAllAttributes(true);
+    m_app->Close(m_doc);
+    m_doc.Nullify();
+    m_app.Nullify();
+
+    return doc->xcaf().diffTopLevelFreeShapes(seqMark);
+#else
+    return false;
+#endif
+}
+
+} // namespace Mayo::IO

--- a/src/io_occ/io_occ_xcaf.h
+++ b/src/io_occ/io_occ_xcaf.h
@@ -1,0 +1,37 @@
+/****************************************************************************
+** Copyright (c) 2016, Fougue SAS <https://www.fougue.pro>
+** SPDX-License-Identifier: BSD-2-Clause
+****************************************************************************/
+
+#pragma once
+
+#include "io_occ_common.h"
+#include "../base/io_reader.h"
+#include "../base/io_writer.h"
+#include "../base/tkernel_utils.h"
+
+#include <Standard_Version.hxx>
+
+#include <type_traits>
+
+class TDocStd_Application;
+
+namespace Mayo::IO {
+
+// Opencascade-based reader for XCAF file format
+class OccXCafReader : public Reader {
+public:
+    OccXCafReader();
+    OccXCafReader(const OccXCafReader&) = delete; // Not copyable
+    OccXCafReader& operator=(const OccXCafReader&) = delete; // Not copyable
+
+    bool readFile(const FilePath& filepath, TaskProgress* progress) override;
+    NCollection_Sequence<TDF_Label> transfer(DocumentPtr doc, TaskProgress* progress) override;
+    void applyProperties(const PropertyGroup*) override {}
+
+private:
+    OccHandle<TDocStd_Application> m_app;
+    OccHandle<TDocStd_Document> m_doc;
+};
+
+} // namespace Mayo::IO


### PR DESCRIPTION
## Contributor Agreement

- [x] I have read and acknowledge the terms of the [Mayo Contributor License Agreement](https://github.com/fougue/mayo/blob/develop/CLA.md)

## Description

Add support for reading XCAF OCCT documents (XBF and XML) and binary BREP format.
Test models could be found in opencascade-dataset:
- BinXCAF:  `xbf/as1_pmi.xbf`
- XmlXCAF:  `xbf/bug33317_solids_7_7_0.xml`
- Binary BREP: `brep/bug32737_degen_elems.bbrep`

<img width="1928" height="1060" alt="image" src="https://github.com/user-attachments/assets/d5a486fb-1be5-4aa1-bfa0-8f48add3c5a9" />

