### PR TITLE
Fix image export on macOS (hang / NSView crash) — closes #403

### DIFF
--- a/src/base/io_system.cpp
+++ b/src/base/io_system.cpp
@@ -15,6 +15,8 @@
 #include "task_progress.h"
 #include "tkernel_utils.h"
 
+#include <Standard_Failure.hxx>
+
 #include <fmt/format.h>
 #include <gsl/util>
 
@@ -48,6 +50,29 @@ void dispatchWarnings(std::string_view headerMsg, const MessageCollecter& msgCol
     const std::string strWarnings = msgCollect.asString("\n    ", MessageType::Warning);
     if (!strWarnings.empty())
         target->warning() << fmt::format("{}\n    {}", headerMsg, strWarnings);
+}
+
+// Executes 'fn' catching any exception it might throw, which is turned into an error message.
+// Reader/writer implementations are third-party code prone to throwing(OpenCascade uses exceptions
+// extensively). An exception escaping a task job would be silently swallowed by std::async and the
+// task would never signal its end, causing the whole application to hang(see issue #403)
+template<typename Function>
+bool safeExecute(Function fn, const std::function<bool(std::string_view)>& fnError)
+{
+    try {
+        return fn();
+    }
+    catch (const Standard_Failure& err) {
+        return fnError(
+            fmt::format("Exception '{}': {}", err.DynamicType()->Name(), err.GetMessageString())
+        );
+    }
+    catch (const std::exception& err) {
+        return fnError(fmt::format("Exception: {}", err.what()));
+    }
+    catch (...) {
+        return fnError("Unknown exception");
+    }
 }
 
 } // namespace
@@ -390,14 +415,18 @@ bool System::exportApplicationItems(const Args_ExportApplicationItems& args) con
     writer->applyProperties(args.parameters);
     {
         TaskProgress transferProgress(progress, 40, textIdTr("Transfer"));
-        const bool okTransfer = writer->transfer(args.applicationItems, &transferProgress);
+        const bool okTransfer = safeExecute(
+            [&]{ return writer->transfer(args.applicationItems, &transferProgress); }, fnError
+        );
         if (!okTransfer)
             return fnError(textIdTr("File transfer problem"));
     }
 
     {
         TaskProgress writeProgress(progress, 60, textIdTr("Write"));
-        const bool okWriteFile = writer->writeFile(args.targetFilepath, &writeProgress);
+        const bool okWriteFile = safeExecute(
+            [&]{ return writer->writeFile(args.targetFilepath, &writeProgress); }, fnError
+        );
         if (!okWriteFile)
             return fnError(textIdTr("File write problem"));
     }

--- a/src/base/task_manager.cpp
+++ b/src/base/task_manager.cpp
@@ -192,8 +192,17 @@ void TaskManager::Private::execEntity(Entity* entity)
         return;
 
     this->taskMgr->signalStarted.send(entity->taskId);
-    const TaskJob& fn = entity->taskJob;
-    fn(&entity->taskProgress);
+    // The task job must never let an exception escape: as tasks are typically run through
+    // std::async whose future is not waited for, the exception would be silently swallowed and the
+    // "ended" signal never sent, leaving any code waiting for task completion stuck forever
+    try {
+        const TaskJob& fn = entity->taskJob;
+        fn(&entity->taskProgress);
+    }
+    catch (...) {
+        // Nothing to report here: the task job is responsible for translating errors into messages
+    }
+
     if (!entity->taskProgress.isAbortRequested())
         entity->taskProgress.setValue(100);
 

--- a/src/cli/cli_export.cpp
+++ b/src/cli/cli_export.cpp
@@ -21,6 +21,7 @@
 #include <QtCore/QtDebug>
 
 #include <fmt/format.h>
+#include <gsl/util>
 #include <atomic>
 #include <functional>
 #include <iomanip>
@@ -126,6 +127,11 @@ bool importInDocument(DocumentPtr doc, const CliExportArgs& args, Helper* helper
 
 void exportDocument(const DocumentPtr& doc, const FilePath& filepath, Helper* helper, TaskProgress* progress)
 {
+    // Whatever happens below(including an exception being thrown), the export task counter has to be
+    // decremented, otherwise the application would never know that all tasks are done and would
+    // wait forever
+    auto _ = gsl::finally([=]{ --(helper->exportTaskCount); });
+
     auto appModule = AppModule::get();
     MessageCollecter errorCollect;
     errorCollect.only(MessageType::Error);
@@ -147,7 +153,6 @@ void exportDocument(const DocumentPtr& doc, const FilePath& filepath, Helper* he
     helper->taskMgr.setTitle(progress->taskId(), msg);
     helper->mapTaskStatus.at(progress->taskId())->success = okExport;
     helper->mapTaskStatus.at(progress->taskId())->finished = true;
-    --(helper->exportTaskCount);
 }
 
 } // namespace

--- a/src/graphics/graphics_create_virtual_window.cpp
+++ b/src/graphics/graphics_create_virtual_window.cpp
@@ -23,12 +23,15 @@
 #if defined(MAYO_OS_WINDOWS)
 #  include <WNT_WClass.hxx>
 #  include <WNT_Window.hxx>
-#elif defined(MAYO_OS_MAC)
-#  include <Cocoa_Window.hxx>
-#elif defined(MAYO_OS_ANDROID)
+#elif defined(MAYO_OS_MAC) || defined(MAYO_OS_ANDROID)
 #  include <Aspect_NeutralWindow.hxx>
 #else
 #  include <Xw_Window.hxx>
+#endif
+
+#ifdef MAYO_OS_MAC
+#  include <OpenGl_Context.hxx>
+#  include <OpenGl_GraphicDriver.hxx>
 #endif
 
 namespace Mayo {
@@ -46,9 +49,15 @@ OccHandle<Aspect_Window> graphicsCreateVirtualWindow(
     }
 
     auto wnd = new WNT_Window("", wClass, WS_POPUP, 0, 0, wndWidth, wndHeight, Quantity_NOC_BLACK);
-#elif defined(MAYO_OS_MAC)
-    auto wnd = new Cocoa_Window("", 0, 0, wndWidth, wndHeight);
-#elif defined(MAYO_OS_ANDROID)
+#elif defined(MAYO_OS_MAC) || defined(MAYO_OS_ANDROID)
+    // Don't use Cocoa_Window on macOS: its constructor allocates a real on-screen NSWindow, which
+    //     * throws Aspect_WindowDefinitionError when NSApp == nullptr(eg. in mayo-conv, which is a
+    //       QCoreApplication and so never instantiates NSApplication)
+    //     * must only ever be done on the main thread, while offscreen rendering typically happens
+    //       in a worker thread
+    // Aspect_NeutralWindow is just a size/position holder without any native window attached, which
+    // is all that is needed: as the window is flagged "virtual", OpenGl_Window doesn't try to bind
+    // the GL context to a native drawable and V3d_View::ToPixMap() renders into an FBO
     auto wnd = new Aspect_NeutralWindow;
     wnd->SetSize(wndWidth, wndHeight);
 #else
@@ -58,6 +67,33 @@ OccHandle<Aspect_Window> graphicsCreateVirtualWindow(
 
     wnd->SetVirtual(true);
     return wnd;
+}
+
+void graphicsPrepareVirtualWindowRendering(
+        [[maybe_unused]]const OccHandle<Graphic3d_GraphicDriver>& gfxDriver
+    )
+{
+#ifdef MAYO_OS_MAC
+    // On macOS the GL context of a virtual window has no drawable attached to it, so its default
+    // framebuffer is incomplete. Any GL call targeting it(eg. glDrawBuffer(GL_BACK), issued by
+    // OpenGl_Window::init()) raises GL_INVALID_FRAMEBUFFER_OPERATION. OpenCascade doesn't reset that
+    // pending error, and later on OpenGl_Texture::Init() reads it back while creating the FBO used
+    // for the offscreen dump: it wrongly concludes that texture creation failed, making
+    // V3d_View::ToPixMap() bail out. Flushing the GL error queue beforehand avoids this false
+    // negative(rendering into an FBO from a drawable-less context works fine otherwise)
+    auto occGfxDriver = OccHandle<OpenGl_GraphicDriver>::DownCast(gfxDriver);
+    if (occGfxDriver.IsNull())
+        return;
+
+    const OccHandle<OpenGl_Context>& gfxContext = occGfxDriver->GetSharedContext();
+    if (gfxContext.IsNull())
+        return;
+
+    // Prefer the context being already current: in the desktop application the graphics driver is
+    // shared with the on-screen view, so avoid stealing "current" from it needlessly
+    if (gfxContext->IsCurrent() || gfxContext->MakeCurrent())
+        gfxContext->ResetErrors(false/*!ToPrintErrors*/);
+#endif
 }
 
 } // namespace Mayo

--- a/src/io_image/io_image.cpp
+++ b/src/io_image/io_image.cpp
@@ -36,6 +36,7 @@ namespace Mayo {
 
 // Defined in graphics_create_virtual_window.cpp
 OccHandle<Aspect_Window> graphicsCreateVirtualWindow(const OccHandle<Graphic3d_GraphicDriver>&, int , int);
+void graphicsPrepareVirtualWindowRendering(const OccHandle<Graphic3d_GraphicDriver>&);
 
 namespace IO {
 
@@ -237,10 +238,19 @@ bool ImageWriter::writeFile(const FilePath& filepath, TaskProgress* progress)
     view->Redraw();
     GraphicsUtils::V3dView_fitAll(view);
     OccHandle<Image_AlienPixMap> pixmap = ImageWriter::createImage(view);
-    if (!pixmap)
+    if (!pixmap) {
+        this->messenger()->emitError(ImageWriterI18N::textIdTr("Failed to dump 3D view into image"));
         return false;
+    }
 
     const bool okSave = pixmap->Save(filepathTo<TCollection_AsciiString>(filepath));
+    if (!okSave) {
+        this->messenger()->emitError(fmt::format(
+            ImageWriterI18N::textIdTr("Failed to save image file(is the image format supported by "
+                                      "the OpenCascade build in use?)")
+        ));
+    }
+
     return okSave;
 }
 
@@ -300,6 +310,9 @@ OccHandle<Image_AlienPixMap> ImageWriter::createImage(OccHandle<V3d_View> view)
     V3d_ImageDumpOptions dumpOptions;
     dumpOptions.BufferType = Graphic3d_BT_RGB;
     view->Window()->Size(dumpOptions.Width, dumpOptions.Height);
+    // Must be called just before dumping: rendering on a virtual window may have left the GL error
+    // state dirty, which would make the dump fail(see graphicsPrepareVirtualWindowRendering())
+    graphicsPrepareVirtualWindowRendering(view->Viewer()->Driver());
     const bool okPixmap = view->ToPixMap(*pixmap.get(), dumpOptions);
     if (!okPixmap)
         return {};
@@ -343,6 +356,7 @@ OccHandle<V3d_View> ImageWriter::createV3dView(GraphicsScene* gfxScene, const Pa
     // Create virtual window
     auto wnd = graphicsCreateVirtualWindow(view->Viewer()->Driver(), params.width, params.height);
     view->SetWindow(wnd);
+    graphicsPrepareVirtualWindowRendering(view->Viewer()->Driver());
 
     return view;
 }


### PR DESCRIPTION
Fixes #403.

> **Attribution:** the code and this description were **written by Claude Opus 5 operating/steered as instructed on behalf of @calumk**. Reviewed before submission. Please scrutinise accordingly.

## Summary

Image export was unusable on macOS. `mayo-conv` hung forever, and the desktop app aborted with the `NSView.m:13477` assertion @HuguesDelorme reproduced on Monterey. There turned out to be **three independent defects** stacked on top of each other — fixing any one alone still leaves export broken.

## 1. `Cocoa_Window` cannot be used for offscreen rendering

`graphicsCreateVirtualWindow()` created a `Cocoa_Window`. Its constructor throws when `NSApp` is null:

```
Aspect_WindowDefinitionError("Cocoa application should be instantiated before window")
```

`NSApp` is *always* null in `mayo-conv`, which builds a `QCoreApplication`. Caught with an lldb throw breakpoint:

```
Cocoa_Window::Cocoa_Window + 464
Mayo::graphicsCreateVirtualWindow
Mayo::IO::ImageWriter::createV3dView
Mayo::IO::ImageWriter::writeFile          ← on thread #4 (std::async worker)
```

`Cocoa_Window` also allocates a real on-screen `NSWindow` and retains its `contentView`. Export runs on a worker thread, and touching `NSView` off the main thread is illegal — **this is the source of the assertion crash in the desktop app**, which is why the GUI failed differently from the CLI.

Fix: use `Aspect_NeutralWindow` on macOS, merging with the existing Android branch. Mayo already relies on `Aspect_NeutralWindow` elsewhere (`OcctNeutralWindow` in `qtopengl_utils.cpp`).

## 2. The exception became an infinite hang

This explains the "hangs, file is not generated" symptom rather than an error message.

`TaskManager::Private::execEntity()` called the job unguarded. The throw escaped into the `std::async` future — which is **stored but never waited on**, so the exception was silently swallowed. Consequently `signalEnded` never fired → `exportTaskCount` never reached zero → `qtApp->exit()` was never called → `QCoreApplication::exec()` blocked forever in `poll()`.

Fix, defence in depth:
- `task_manager.cpp` — guard the job call so `signalEnded` is always emitted and `isFinished` always set.
- `io_system.cpp` — wrap writer `transfer`/`writeFile` in a helper that catches `Standard_Failure` (reporting `DynamicType()->Name()` + `GetMessageString()`), `std::exception` and `...`.
- `cli_export.cpp` — `gsl::finally` so the task counter is always decremented.

Any OCCT throw in an export path now surfaces as a proper error message instead of a hang.

## 3. `ToPixMap()` failed on a stale GL error

Only visible after #1 was fixed:

```
2D texture 128x128 IF: GL_SRGB8_ALPHA8 PF: GL_RGBA DT: GL_UNSIGNED_BYTE
can not be created with error GL_INVALID_FRAMEBUFFER_OPERATION [:color]
Warning, on screen buffer is used for image dump - content might be invalid
```

A drawable-less GL context has an incomplete default framebuffer, so OCCT's own `glDrawBuffer(GL_BACK)` in `OpenGl_Window::init()` raises `GL_INVALID_FRAMEBUFFER_OPERATION` and never clears it. `OpenGl_Texture::Init()` then reads that **stale** error while building the dump FBO and wrongly concludes texture creation failed.

Confirmed a false negative with a standalone probe: a view-less `NSOpenGLContext` (GL_VERSION `4.1 Metal - 90.5`) created the same texture with error `0x0`, got `FBO status = GL_FRAMEBUFFER_COMPLETE`, and read back the expected pixels. A/B test in-tree: without the error reset `ToPixMap` returns 0; with it, 1.

Fix: add `graphicsPrepareVirtualWindowRendering()`, which makes the context current and calls `ResetErrors()`. It must be called **immediately before `ToPixMap()`** — doing it only at view creation is too early, because `Redraw()` re-raises the error.

Also: `ImageWriter::writeFile()` now emits real errors instead of `return false` silently.

## Testing

macOS 26.5 arm64 (M-series), Qt 6.10.2, OpenCascade 7.9.3, AppleClang 21.

- `mayo-conv` and the desktop app both export successfully; **no hang, no assertion crash**
- Inputs verified: STEP, IGES, BREP, OBJ, STLB, PLY, glTF
- Sizes up to 3840×2160
- Two concurrent `--export` targets in one invocation
- Invalid input now produces a clean error and exit code 0 instead of hanging
- Output images inspected visually — real geometry, not blank frames
- **Test suite: 225 passed, 0 failed**

### Caveats

- **Only tested on macOS arm64.** I have no Linux or Windows machine here. The `Aspect_NeutralWindow` change is inside `#elif defined(MAYO_OS_MAC) || defined(MAYO_OS_ANDROID)` so other platforms are untouched, but the `task_manager.cpp` and `io_system.cpp` changes are cross-platform and deserve a look — they are defensive only and change no success-path behaviour.
- Worth confirming on an Intel Mac; the probe was arm64.
- Homebrew's OCCT is built **without** FreeImage, so `Image_AlienPixMap::Save()` writes Netpbm/PPM data whatever the extension (`file` reports `Netpbm image data`, header `P6`). That is an OCCT packaging matter, not a Mayo bug, but it does mean `.png` output is not really PNG on a stock Homebrew install.

## Related

A **fourth, unrelated** defect surfaced once export worked: BRep inputs render as wireframe because `mayo-conv` never meshes them for image export. That is deliberately **not** in this PR — filed as #412 with its own fix in #413.

#413 also touches `src/cli/cli_export.cpp`, so whichever of the two merges second may need a trivial rebase. The hunks are adjacent but distinct: this PR adds a `gsl::finally` in `exportDocument()`, #413 changes the meshing predicate in `importInDocument()`.

I acknowledge `CLA.md` applies to this contribution.

