### PR TITLE
cli: mesh BRep shapes when exporting to image — closes #412

### DIFF
--- a/src/cli/cli_export.cpp
+++ b/src/cli/cli_export.cpp
@@ -95,11 +95,14 @@ bool importInDocument(DocumentPtr doc, const CliExportArgs& args, Helper* helper
 {
     auto appModule = AppModule::get();
 
-    // If export operation targets some mesh format then force meshing of imported BRep shapes
+    // If export operation targets some mesh format then force meshing of imported BRep shapes.
+    // Image export also requires a mesh: GraphicsShapeObjectDriver disables auto-triangulation, so
+    // without an explicit mesh the BRep shapes have no triangulation to shade and are rendered as
+    // wireframe only.
     bool brepMeshRequired = false;
     for (const FilePath& filepath : args.filesToExport) {
         const IO::Format format = appModule->ioSystem()->probeFormat(filepath);
-        brepMeshRequired = IO::formatProvidesMesh(format);
+        brepMeshRequired = IO::formatProvidesMesh(format) || format == IO::Format_Image;
         if (brepMeshRequired)
             break; // Interrupt
     }


### PR DESCRIPTION
Fixes #412.

> **Attribution:** the code and this description were **written by Claude Opus 5 operating/steered as instructed on behalf of @calumk**. Reviewed before submission.

## Problem

`mayo-conv` produces wireframe-only images for BRep inputs (STEP, IGES, BREP, DXF). Export succeeds and the file is valid, but only edges are drawn.

`importInDocument()` in `src/cli/cli_export.cpp` gates meshing on:

```cpp
brepMeshRequired = IO::formatProvidesMesh(format);
```

and `formatProvidesMesh()` explicitly excludes `Format_Image`, so no mesh is ever computed. Since `GraphicsShapeObjectDriver::createObject()` sets `Attributes()->SetAutoTriangulation(false)`, OCCT will not triangulate on demand either — `AIS_Shaded` with no triangulation draws only edges.

Mesh inputs (STL, OBJ, PLY, glTF) already carry a triangulation, which is why they rendered correctly and masked this.

Worth stressing: this is **not** a display-mode problem. `Image\GraphicsShapeObjectDriver_displayMode` correctly defaults to `ShadedWithFaceBoundary` and `createObject()` already calls `SetDisplayMode(AIS_Shaded)`. The shaded mode is set; there is just no surface to shade.

## Fix

One line:

```cpp
brepMeshRequired = IO::formatProvidesMesh(format) || format == IO::Format_Image;
```

`formatProvidesMesh()` is left **unchanged** — it correctly describes whether a *file format* carries mesh data, which is `false` for an image. The defect was the caller conflating "format stores a mesh" with "rendering needs a mesh". If you would rather express this as a dedicated predicate (`formatRequiresMesh()`), I am glad to rework it.

## Scope

- **`mayo-conv` only** — the desktop app passes `withEntityPostProcessRequiredIf(&IO::formatProvidesBRep)` in `commands_file.cpp` and always meshes BRep shapes, so it was never affected.
- **Platform-independent** — no platform guards in `cli_export.cpp`; unrelated to the macOS defects in #403 / #411.
- Previously invisible on macOS because image export failed outright.

## Verification

Non-background pixel coverage of a rendered cube, sampling every 4th pixel at 1024×768:

| input | before | after |
|---|---|---|
| `cube.step` | 0.3% | **47.7%** |
| `cube.iges` | 0.3% | **47.7%** |
| `cube.brep` | 0.3% | **47.7%** |
| `cube.stlb` | 47.8% | 47.8% (unchanged) |
| `cube.obj` | 47.8% | 47.8% (unchanged) |
| `cube.gltf` | 47.7% | 47.7% (unchanged) |
| `cube.ply` | 47.8% | 47.8% (unchanged) |

BRep inputs now match the mesh baseline exactly; mesh inputs are untouched, confirming no unintended re-meshing. Output inspected visually: solid shaded faces with black boundary edges.

**Test suite: 225 passed, 0 failed.** macOS 26.5 arm64, Qt 6.10.2, OpenCascade 7.9.3. Not verified on Linux or Windows, though nothing here is platform-specific.

## Notes for review

- This PR is based on `develop` and is **independent of #411**. Both touch `src/cli/cli_export.cpp`, so whichever merges second may need a trivial rebase — the hunks are adjacent but distinct (this one changes the meshing predicate; #411 adds a `gsl::finally` further down the file).
- On macOS you need #411 merged to *observe* either behaviour, since image export fails outright without it. On Linux and Windows this fix is independently testable today.
- Image export now runs the mesher, so `[meshing] meshingQuality` affects output sharpness on curved geometry, and exporting very large assemblies will be slower. This matches the desktop app's existing behaviour and seems correct, but it is a deliberate behavioural change worth flagging.

I acknowledge `CLA.md` applies to this contribution.
