### PR TITLE
feat: add shortcut(H key) for toggle object visibility when it is selected in 3d viewport

### DIFF
--- a/src/app/widget_gui_document.cpp
+++ b/src/app/widget_gui_document.cpp
@@ -28,6 +28,9 @@
 #include <QtWidgets/QWidgetAction>
 #include <Standard_Version.hxx>
 
+#include <algorithm>
+#include <vector>
+
 namespace Mayo {
 
 namespace {
@@ -69,6 +72,18 @@ private:
 
 // Default margin to be used in widgets
 const int Internal_widgetMargin = 4;
+
+std::vector<TreeNodeId> getSelectedNodeIds(const GuiDocument* guiDoc)
+{
+    std::vector<TreeNodeId> nodeIds;
+    const GuiApplication* guiApp = guiDoc->guiApplication();
+    for (const ApplicationItem& appItem : guiApp->selectionModel()->selectedItems()) {
+        if (appItem.isDocumentTreeNode() && appItem.document() == guiDoc->document())
+            nodeIds.push_back(appItem.documentTreeNode().id());
+    }
+
+    return nodeIds;
+}
 
 } // namespace
 
@@ -138,6 +153,20 @@ WidgetGuiDocument::WidgetGuiDocument(GuiDocument* guiDoc, QWidget* parent)
     m_controller->signalMultiSelectionToggled.connectSlot([=](bool on) {
         auto mode = on ? GraphicsScene::SelectionMode::Multi : GraphicsScene::SelectionMode::Single;
         gfxScene->setSelectionMode(mode);
+    });
+    m_controller->signalToggleSelectionVisibilityRequested.connectSlot([=]{
+        const auto vecSelectedNodeId = getSelectedNodeIds(m_guiDoc);
+        if (vecSelectedNodeId.empty())
+            return;
+
+        const bool allSelectedItemVisible = std::all_of(
+            vecSelectedNodeId.cbegin(), vecSelectedNodeId.cend(),
+            [=](TreeNodeId nodeId) { return m_guiDoc->nodeVisibleState(nodeId) == CheckState::On; }
+        );
+        for (TreeNodeId nodeId : vecSelectedNodeId)
+            m_guiDoc->setNodeVisible(nodeId, !allSelectedItemVisible);
+
+        m_guiDoc->graphicsScene()->redraw();
     });
 
     m_guiDoc->viewCameraAnimation()->setBackend(std::make_unique<QtAnimationBackend>(QEasingCurve::OutExpo));
@@ -399,15 +428,7 @@ void WidgetGuiDocument::createMenuItemVisibility(QWidget* container)
 
     const DocumentPtr doc = m_guiDoc->document();
     // Helper function to get the selected tree nodes(ids) in the document
-    auto fnGetDocSelectedNodeIds = [=]() -> std::vector<TreeNodeId> {
-        std::vector<TreeNodeId> nodeIds;
-        const GuiApplication* guiApp = m_guiDoc->guiApplication();
-        for (const ApplicationItem& appItem : guiApp->selectionModel()->selectedItems()) {
-            if (appItem.isDocumentTreeNode() && appItem.document() == m_guiDoc->document())
-                nodeIds.push_back(appItem.documentTreeNode().id());
-        }
-        return nodeIds;
-    };
+    auto fnGetDocSelectedNodeIds = [=] { return getSelectedNodeIds(m_guiDoc); };
 
     // "Show all" action
     QObject::connect(actionShowAll, &QAction::triggered, this, [=]{

--- a/src/app/widget_occ_view_controller.cpp
+++ b/src/app/widget_occ_view_controller.cpp
@@ -210,6 +210,9 @@ void WidgetOccViewController::handleKeyPress(const QKeyEvent* event)
         return;
 
     m_inputSequence.push(event->key());
+    if (m_inputSequence.equal({ Qt::Key_H }))
+        this->signalToggleSelectionVisibilityRequested.send();
+
     if (m_inputSequence.equal({ Qt::Key_Space }))
         this->startInstantZoom(toPosition(m_occView->widget()->mapFromGlobal(QCursor::pos())));
 

--- a/src/gui/v3d_view_controller.h
+++ b/src/gui/v3d_view_controller.h
@@ -56,6 +56,7 @@ public:
     Signal<int, int> signalMouseMoved; // x,y: mouse position in view
     Signal<Aspect_VKeyMouse> signalMouseButtonClicked;
     Signal<bool> signalMultiSelectionToggled;
+    Signal<> signalToggleSelectionVisibilityRequested;
 
 protected:
     struct Position { int x; int y; };


### PR DESCRIPTION
## Contributor Agreement

- [x] I have read and acknowledge the terms of the [Mayo Contributor License Agreement](https://github.com/fougue/mayo/blob/develop/CLA.md)

<!-- Required: Pull Requests without this box checked may not be reviewed or merged -->

## Description

Mayo only support toggle object visibility by `space` key when it is selected in model tree, 
so I add `H` key for toggle object visibility when it is selected in 3d viewport,
when use `H` key, cause `space` key is used by `instant zoom`.

## GitHub Issue

https://github.com/fougue/mayo/discussions/410